### PR TITLE
fix archRulesTest compile and runtime classpaths

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPlugin.kt
@@ -62,7 +62,7 @@ class ArchrulesLibraryPlugin : Plugin<Project> {
                         useJUnitJupiter()
                         dependencies {
                             implementation(project())
-                            implementation(archRulesSourceSet.output)
+                            implementation(archRulesSourceSet.runtimeClasspath)
                             implementation("com.netflix.nebula:nebula-archrules-core:$version")
                         }
                         javaExt.sourceSets.named("archRulesTest").configure {

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/TestKitDslExtensions.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/TestKitDslExtensions.kt
@@ -37,6 +37,31 @@ public class LibraryClass {
     )
 }
 
+fun SourceSetBuilder.exampleHelperClass() {
+    java(
+        "com/example/library/HaveNoTests.java",
+        //language=java
+        """
+package com.example.library;
+                            
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+
+public class HaveNoTests extends DescribedPredicate<JavaClass> {
+    public HaveNoTests() {
+        super("have no tests");
+    }
+
+    @Override
+    public boolean test(JavaClass javaClass) {
+        return javaClass.getMembers().stream()
+                .noneMatch(it -> it.isAnnotatedWith("org.junit.jupiter.api.Test"));
+    }
+}
+"""
+    )
+}
+
 fun SourceSetBuilder.exampleDeprecatedArchRule() {
     java(
         "com/example/library/LibraryArchRules.java",
@@ -66,6 +91,43 @@ public class LibraryArchRules implements ArchRulesService {
     @Override
     public Map<String, ArchRule> getRules() {
         return Map.of("deprecated", noDeprecated);
+    }
+}
+"""
+    )
+}
+
+fun SourceSetBuilder.exampleNullabilityArchRule() {
+    java(
+        "com/example/library/NullabilityArchRules.java",
+        //language=java
+        """
+package com.example.library;
+
+import com.netflix.nebula.archrules.core.ArchRulesService;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.properties.HasModifiers;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.Priority;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import java.util.Map;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.fullyQualifiedName;
+
+public class NullabilityArchRules implements ArchRulesService {
+    public static final ArchRule PUBLIC_CLASSES_SHOULD_BE_NULL_MARKED = ArchRuleDefinition.priority(Priority.MEDIUM)
+            .classes().that()
+            .areTopLevelClasses()
+            .and().arePublic()
+            .and().containAnyMembersThat(HasModifiers.Predicates.modifier(JavaModifier.PUBLIC))
+            .and(new HaveNoTests())
+            .and().areNotAnnotatedWith("kotlin.Metadata")
+            .should().beAnnotatedWith("org.jspecify.annotations.NullMarked")
+            .allowEmptyShould(true)
+            .because("public classes should be null marked");
+            
+    @Override
+    public Map<String, ArchRule> getRules() {
+        return Map.of("public classes should be @NullMarked", PUBLIC_CLASSES_SHOULD_BE_NULL_MARKED);
     }
 }
 """
@@ -125,6 +187,59 @@ public class LibraryArchRulesTest {
     @Test
     public void test_fail() {
         EvaluationResult result = Runner.check(LibraryArchRules.noDeprecated, FailingCode.class);
+        Assertions.assertTrue(result.hasViolation());
+    }
+}
+"""
+    )
+}
+
+fun SourceSetBuilder.exampleTestForNullabilityArchRule() {
+    java("com/example/library/FailingCode.java",
+        //language=java
+        """
+package com.example.library;
+public class FailingCode {
+    public void aMethod() {
+    }
+}
+        """)
+    java("com/example/library/PassingCode.java",
+        //language=java
+        """
+package com.example.library;
+import org.jspecify.annotations.NullMarked;
+@NullMarked
+public class PassingCode {
+    public void aMethod() {
+    }
+}
+        """)
+    java(
+        "com/example/library/NullabilityArchRulesTest.java",
+        //language=java
+        """
+package com.example.library;
+
+import com.netflix.nebula.archrules.core.ArchRulesService;
+import com.netflix.nebula.archrules.core.Runner;
+import com.tngtech.archunit.lang.EvaluationResult;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class NullabilityArchRulesTest {
+
+    @Test
+    public void test_pass() {
+        EvaluationResult result = Runner.check(NullabilityArchRules.PUBLIC_CLASSES_SHOULD_BE_NULL_MARKED, PassingCode.class);
+        Assertions.assertFalse(result.hasViolation());
+    }
+        
+    @Test
+    public void test_fail() {
+        EvaluationResult result = Runner.check(NullabilityArchRules.PUBLIC_CLASSES_SHOULD_BE_NULL_MARKED, FailingCode.class);
         Assertions.assertTrue(result.hasViolation());
     }
 }


### PR DESCRIPTION
archRulesTest compile and runtime classpaths should include all dependencies from archRules source set

fixes #26