### PR TITLE
add extension option for skipping passing summary lines in the console report

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ archRules {
 }
 ```
 
+You can also disable printing summary lines for passing rules to reduce noise:
+```kotlin
+archRules {
+    skipPassingSummaries = true
+}
+```
+
 ## How it works
 
 The Archrules Library plugin produces a separate Jar for the `archRules` sourceset, which is exposed as an alternate variant of the library. It also will automatically generate a `META-INF/services` file which contains a reference for each implementation of `com.netflix.nebula.archrules.core.ArchRulesService` to declare it as a service provider.

--- a/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/PrintConsoleReportTask.java
+++ b/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/PrintConsoleReportTask.java
@@ -3,6 +3,7 @@ package com.netflix.nebula.archrules.gradle;
 import com.tngtech.archunit.lang.Priority;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
@@ -25,6 +26,13 @@ abstract public class PrintConsoleReportTask extends DefaultTask {
     @PathSensitive(PathSensitivity.RELATIVE)
     abstract public ListProperty<@NonNull File> getDataFiles();
 
+    /**
+     * The data files to read in. These files should container binary data representing {@link RuleResult}s
+     * @return all data files to process
+     */
+    @Input
+    abstract public Property<@NonNull Boolean> getSummaryForPassingDisabled();
+
     @TaskAction
     public void printReport() {
         final var consoleOutput = getServices().get(StyledTextOutputFactory.class).create("archrules");
@@ -32,7 +40,7 @@ abstract public class PrintConsoleReportTask extends DefaultTask {
                 .flatMap(it -> ViolationsUtil.readDetails(it).stream())
                 .toList();
         final var byRule = ViolationsUtil.consolidatedFailures(list);
-        ViolationsUtil.printSummary(byRule, consoleOutput);
+        ViolationsUtil.printSummary(byRule, consoleOutput, getSummaryForPassingDisabled().get());
         if (list.stream().anyMatch(it -> it.status() != RuleResultStatus.FAIL && it.rule().priority() == Priority.LOW) && !getLogger().isInfoEnabled()) {
             consoleOutput.style(StyledTextOutput.Style.Header)
                     .text("Note: ")

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesExtension.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesExtension.kt
@@ -4,4 +4,5 @@ import org.gradle.api.provider.Property
 
 abstract class ArchrulesExtension {
     abstract val consoleReportEnabled: Property<Boolean>
+    abstract val skipPassingSummaries: Property<Boolean>
 }

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
@@ -30,6 +30,7 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
         project.plugins.withId("java") {
             val archRulesExt = project.extensions.create<ArchrulesExtension>("archRules")
             archRulesExt.consoleReportEnabled.convention(true)
+            archRulesExt.skipPassingSummaries.convention(false)
             project.extensions.getByType<JavaPluginExtension>().sourceSets
                 .configureEach {
                     project.configureCheckTaskForSourceSet(this)
@@ -47,6 +48,7 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
                 getDataFiles().set(
                     project.provider { (project.tasks.withType<CheckRulesTask>().flatMap { it.outputs.files }) }
                 )
+                summaryForPassingDisabled.set(archRulesExt.skipPassingSummaries)
                 dependsOn(checkTasks)
                 onlyIf { archRulesExt.consoleReportEnabled.get() }
             }

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ViolationsUtil.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ViolationsUtil.kt
@@ -55,7 +55,7 @@ class ViolationsUtil {
         }
 
         @JvmStatic
-        fun printSummary(resultMap: Map<Rule, List<RuleResult>>, output: StyledTextOutput) {
+        fun printSummary(resultMap: Map<Rule, List<RuleResult>>, output: StyledTextOutput, skipPassing: Boolean) {
             val indent = 4
             val maxRuleNameLength = resultMap.keys.maxOfOrNull { it.ruleName().length } ?: 1
             resultMap.entries.groupBy { entry -> entry.key.ruleClass() }
@@ -64,12 +64,14 @@ class ViolationsUtil {
                     classMap.forEach { (rule, results) ->
                         val failures = results.filter { it.status() != RuleResultStatus.PASS }
                         if (failures.isEmpty()) {
-                            output.style(StyledTextOutput.Style.Success)
-                                .text(" ".repeat(indent))
-                                .text(rule.ruleName().padEnd(maxRuleNameLength + 1))
-                                .text(" ")
-                                .text(rule.priority().asString().padEnd(10))
-                                .println(" (No failures)")
+                            if (!skipPassing) {
+                                output.style(StyledTextOutput.Style.Success)
+                                    .text(" ".repeat(indent))
+                                    .text(rule.ruleName().padEnd(maxRuleNameLength + 1))
+                                    .text(" ")
+                                    .text(rule.priority().asString().padEnd(10))
+                                    .println(" (No failures)")
+                            }
                         } else {
                             val style = when (rule.priority()) {
                                 Priority.LOW -> StyledTextOutput.Style.Normal
@@ -84,7 +86,7 @@ class ViolationsUtil {
                                 .println(" (" + failures.size + " failures)")
                         }
                     }
-            }
+                }
         }
 
         /**

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ViolationsUtilTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ViolationsUtilTest.kt
@@ -12,14 +12,27 @@ internal class ViolationsUtilTest {
         val output = MockStyledTextOutput()
         val rule = Rule("RuleClass", "RuleName", "description", Priority.MEDIUM)
         val results = listOf(RuleResult(rule, "message", RuleResultStatus.PASS))
-        ViolationsUtil.printSummary(mapOf(rule to results), output)
-        assertThat(output.getOutput()).contains("RuleName  MEDIUM     (No failures)")
+        ViolationsUtil.printSummary(mapOf(rule to results), output, false)
+        assertThat(output.getOutput())
+            .contains("RuleClass")
+            .contains("RuleName  MEDIUM     (No failures)")
+    }
+
+    @Test
+    fun `test printSummary skipPassing`() {
+        val output = MockStyledTextOutput()
+        val rule = Rule("RuleClass", "RuleName", "description", Priority.MEDIUM)
+        val results = listOf(RuleResult(rule, "message", RuleResultStatus.PASS))
+        ViolationsUtil.printSummary(mapOf(rule to results), output, true)
+        assertThat(output.getOutput())
+            .contains("RuleClass")
+            .doesNotContain("RuleName")
     }
 
     @Test
     fun `test printSummary empty results`() {
         val output = MockStyledTextOutput()
-        ViolationsUtil.printSummary(mapOf(), output)
+        ViolationsUtil.printSummary(mapOf(), output, false)
         assertThat(output.getOutput()).isEmpty()
     }
 }


### PR DESCRIPTION
add extension option for skipping passing summary lines in the console report

```
archRules {
    skipPassingSummaries = true
}
```