### PR TITLE
add extension option for skipping running rules in specific source sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ archRules {
 }
 ```
 
+You can skip running rules on a specific source set:
+```kotlin
+archRules {
+    skipSourceSet("test")
+}
+```
+The `archRulesTest` source set is skipped by default.
+
 ## How it works
 
 The Archrules Library plugin produces a separate Jar for the `archRules` sourceset, which is exposed as an alternate variant of the library. It also will automatically generate a `META-INF/services` file which contains a reference for each implementation of `com.netflix.nebula.archrules.core.ArchRulesService` to declare it as a service provider.

--- a/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/PrintConsoleReportTask.java
+++ b/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/PrintConsoleReportTask.java
@@ -37,6 +37,7 @@ abstract public class PrintConsoleReportTask extends DefaultTask {
     public void printReport() {
         final var consoleOutput = getServices().get(StyledTextOutputFactory.class).create("archrules");
         List<RuleResult> list = getDataFiles().get().stream()
+                .filter(File::exists)
                 .flatMap(it -> ViolationsUtil.readDetails(it).stream())
                 .toList();
         final var byRule = ViolationsUtil.consolidatedFailures(list);

--- a/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/PrintJsonReportTask.java
+++ b/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/PrintJsonReportTask.java
@@ -37,6 +37,7 @@ abstract public class PrintJsonReportTask extends DefaultTask {
     @TaskAction
     public void printReport() {
         List<RuleResult> list = getDataFiles().get().stream()
+                .filter(File::exists)
                 .flatMap(it -> ViolationsUtil.readDetails(it).stream())
                 .toList();
 

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesExtension.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesExtension.kt
@@ -1,8 +1,24 @@
 package com.netflix.nebula.archrules.gradle
 
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
 abstract class ArchrulesExtension {
+    /**
+     * set to false to disable the console report
+     */
     abstract val consoleReportEnabled: Property<Boolean>
+
+    /**
+     * Skip printing lines in the console report summary for passing rules
+     */
     abstract val skipPassingSummaries: Property<Boolean>
+    abstract val sourceSetsToSkip: ListProperty<String>
+
+    /**
+     * Add a source set to the list of sourcesets to skip
+     */
+    fun skipSourceSet(name: String) {
+        sourceSetsToSkip.add(name)
+    }
 }


### PR DESCRIPTION
example:
```
archRules {
    skipSourceSet("test")
}     
```