### PR TITLE
prevent creating task and configuration for skipped source sets

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
@@ -34,7 +34,9 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
             archRulesExt.sourceSetsToSkip.add("archRulesTest")
             project.extensions.getByType<JavaPluginExtension>().sourceSets
                 .configureEach {
-                    project.configureCheckTaskForSourceSet(this, archRulesExt)
+                    if(!archRulesExt.sourceSetsToSkip.get().contains(this.name)) {
+                        project.configureCheckTaskForSourceSet(this)
+                    }
                 }
             val checkTasks = project.tasks.withType<CheckRulesTask>()
             val jsonReportTask = project.tasks.register<PrintJsonReportTask>("archRulesJsonReport") {
@@ -61,7 +63,7 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
         }
     }
 
-    fun Project.configureCheckTaskForSourceSet(sourceSet: SourceSet, ext: ArchrulesExtension) {
+    fun Project.configureCheckTaskForSourceSet(sourceSet: SourceSet) {
         val archRulesReportDir = project.layout.buildDirectory.dir("reports/archrules")
         val sourceSetArchRulesRuntime = configurations.resolvable(sourceSet.name + "ArchRulesRuntime") {
             extendsFrom(
@@ -80,8 +82,6 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
             })
             sourcesToCheck.from(sourceSet.output.classesDirs)
             dependsOn(project.tasks.named(sourceSet.classesTaskName))
-            val sourceSetName = sourceSet.name
-            onlyIf { !ext.sourceSetsToSkip.get().contains(sourceSetName) }
         }
     }
 }

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
@@ -426,8 +426,8 @@ archRules {
             .hasOutcome(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE)
 
         assertThat(result.task(":checkArchRulesArchRulesTest"))
-            .`as`("archRules run for test source set")
-            .hasOutcome(TaskOutcome.SKIPPED)
+            .`as`("archRules don't run for archRulesTest source set")
+            .isNull()
 
         assertThat(result)
             .hasNoMutableStateWarnings()
@@ -480,8 +480,8 @@ archRules {
             .hasOutcome(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE)
 
         assertThat(result.task(":checkArchRulesTest"))
-            .`as`("archRules run for test source set")
-            .hasOutcome(TaskOutcome.SKIPPED)
+            .`as`("archRules don't run for test source set")
+            .isNull()
 
         assertThat(result)
             .hasNoMutableStateWarnings()


### PR DESCRIPTION
this will prevent configuration cache errors since these configurations are never resolved