### PR TITLE
allow certain rules to be skipped for certain source sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ archRules {
 
 The `ruleName` will take precedent over the `ruleClass`.
 
+#### Disabling specific rules
+You can skip evaluating certain rules on specific source sets:
+```kotlin
+archRules {
+    ruleClass("com.netflix.nebula.archrules.deprecation") {
+        skipSourceSet("test")
+    }
+    ruleName("deprecated") {
+        skipSourceSet("test")
+    }
+}
+```
+
 #### Configuring which code is tested
 
 You can skip running rules on a specific source set:

--- a/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/RunRulesParams.java
+++ b/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/RunRulesParams.java
@@ -2,19 +2,25 @@ package com.netflix.nebula.archrules.gradle;
 
 import com.tngtech.archunit.lang.Priority;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.workers.WorkParameters;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.io.File;
 
+@NullMarked
 public interface RunRulesParams extends WorkParameters {
     ConfigurableFileCollection getClassesToCheck();
 
-    Property<@NonNull File> getDataOutputFile();
+    Property<File> getDataOutputFile();
 
-    MapProperty<@NonNull String, @NonNull Priority> getPriorityOverridesByName();
+    MapProperty<String, Priority> getPriorityOverridesByName();
 
-    MapProperty<@NonNull String, @NonNull Priority> getPriorityOverridesByClass();
+    MapProperty<String, Priority> getPriorityOverridesByClass();
+
+    ListProperty<String> getExcludedRules();
+
+    ListProperty<String> getExcludedRuleClasses();
 }

--- a/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/RunRulesWorkAction.java
+++ b/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/RunRulesWorkAction.java
@@ -5,6 +5,7 @@ import com.netflix.nebula.archrules.core.Runner;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.Priority;
 import org.gradle.workers.WorkAction;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,13 +16,50 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
 import static com.netflix.nebula.archrules.core.NoClassesMatchedEvent.NO_MATCH_MESSAGE;
 
+@NullMarked
 public abstract class RunRulesWorkAction implements WorkAction<RunRulesParams> {
     private static final Logger LOGGER = LoggerFactory.getLogger(RunRulesWorkAction.class);
+
+    boolean isRuleClassExcluded(String ruleClassName) {
+        for (String exclusion : getParameters().getExcludedRuleClasses().get()) {
+            if (ruleClassName.startsWith(exclusion)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    Optional<Priority> getPriorityOverride(String ruleClassName, String ruleId) {
+        Priority priority = null;
+
+        // check for exact rule match first
+        final var overridesByName = getParameters().getPriorityOverridesByName().getOrElse(Map.of());
+        if (overridesByName.containsKey(ruleId)) {
+            priority = overridesByName.get(ruleId);
+        }
+
+        if (priority == null) { // if no exact rule match, maybe there is a class-level match
+            String classNameMatch = "";
+            final var overridesByClass = getParameters().getPriorityOverridesByClass().getOrElse(Map.of());
+            for (Map.Entry<String, Priority> override : overridesByClass.entrySet()) {
+                String overrideRuleName = override.getKey();
+                if (ruleClassName.startsWith(overrideRuleName)) {
+                    if (overrideRuleName.length() > classNameMatch.length()) { // prefer more specific
+                        priority = override.getValue();
+                        classNameMatch = overrideRuleName;
+                    }
+                }
+            }
+        }
+
+        return Optional.ofNullable(priority);
+    }
 
     @Override
     public void execute() {
@@ -34,40 +72,37 @@ public abstract class RunRulesWorkAction implements WorkAction<RunRulesParams> {
         final var classesToCheck = new ClassFileImporter()
                 .importPaths(getParameters().getClassesToCheck().getFiles().stream().map(File::toPath).toList());
         final List<RuleResult> violationList = new ArrayList<>();
-        final var overridesByName = getParameters().getPriorityOverridesByName().getOrElse(Map.of());
-        final var overridesByClass = getParameters().getPriorityOverridesByClass().getOrElse(Map.of());
 
-        ruleClasses.forEach(ruleClass -> ruleClass.getRules().forEach((id, archRule) -> {
-            final var result = Runner.check(archRule, classesToCheck);
-
-            // check if there is priority override by class first
-            var priority = result.getPriority();
+        ruleClasses.forEach(ruleClass -> {
             String ruleClassName = ruleClass.getClass().getCanonicalName();
-            for (Map.Entry<String, Priority> override : overridesByClass.entrySet()) {
-                String overrideRuleName = override.getKey();
-                if (ruleClassName.startsWith(overrideRuleName)) {
-                    priority = override.getValue();
-                    break;
-                }
-            }
-            // then check if there is a priority override by name
-            if (overridesByName.containsKey(id)) {
-                priority = overridesByName.get(id);
-            }
-
-            final var rule = new Rule(ruleClassName, id, archRule.getDescription(), priority);
-            if (result.hasViolation()) {
-                result.getFailureReport().getDetails().forEach(detail -> {
-                    if (detail.equals(NO_MATCH_MESSAGE)) {
-                        violationList.add(new RuleResult(rule, detail, RuleResultStatus.NO_MATCH));
+            if (isRuleClassExcluded(ruleClassName)) {
+                LOGGER.info("Rule class {} has been excluded for this source set", ruleClass.getClass().getName());
+            } else {
+                ruleClass.getRules().forEach((id, archRule) -> {
+                    if (getParameters().getExcludedRules().get().contains(id)) {
+                        LOGGER.info("Rule {} has been excluded for this source set", id);
                     } else {
-                        violationList.add(new RuleResult(rule, detail, RuleResultStatus.FAIL));
+                        final var result = Runner.check(archRule, classesToCheck);
+
+                        // check if there is priority override by class first
+                        var priority = getPriorityOverride(ruleClassName, id).orElse(result.getPriority());
+
+                        final var rule = new Rule(ruleClassName, id, archRule.getDescription(), priority);
+                        if (result.hasViolation()) {
+                            result.getFailureReport().getDetails().forEach(detail -> {
+                                if (detail.equals(NO_MATCH_MESSAGE)) {
+                                    violationList.add(new RuleResult(rule, detail, RuleResultStatus.NO_MATCH));
+                                } else {
+                                    violationList.add(new RuleResult(rule, detail, RuleResultStatus.FAIL));
+                                }
+                            });
+                        } else {
+                            violationList.add(new RuleResult(rule, "", RuleResultStatus.PASS));
+                        }
                     }
                 });
-            } else {
-                violationList.add(new RuleResult(rule, "", RuleResultStatus.PASS));
             }
-        }));
+        });
 
         try (var out = new ObjectOutputStream(new FileOutputStream(getParameters().getDataOutputFile().get()))) {
             out.writeInt(violationList.size());

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesExtension.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesExtension.kt
@@ -21,11 +21,8 @@ abstract class ArchrulesExtension {
     abstract val failureThreshold: Property<Priority>
     abstract val consoleDetailsThreshold: Property<Priority>
 
-    /**
-     * Allow priority overrides
-     */
-    abstract val priorityOverridesByRuleName: MapProperty<String, Priority>
-    abstract val priorityOverridesByRuleClass: MapProperty<String, Priority>
+    abstract val ruleOverrides: MapProperty<String, RuleConfig>
+    abstract val ruleClassOverrides: MapProperty<String, RuleConfig>
 
     /**
      * Add a source set to the list of sourcesets to skip
@@ -52,29 +49,14 @@ abstract class ArchrulesExtension {
 
     @Deprecated("use ruleName instead")
     fun rule(ruleName: String, action: Action<RuleConfig>) {
-        val config = RuleConfig()
-        action.execute(config)
-
-        config.priority?.let { priority ->
-            priorityOverridesByRuleName.put(ruleName, priority)
-        }
+        ruleOverrides.put(ruleName, RuleConfig().apply { action.execute(this) })
     }
 
     fun ruleName(ruleName: String, action: Action<RuleConfig>) {
-        val config = RuleConfig()
-        action.execute(config)
-
-        config.priority?.let { priority ->
-            priorityOverridesByRuleName.put(ruleName, priority)
-        }
+        ruleOverrides.put(ruleName, RuleConfig().apply { action.execute(this) })
     }
 
     fun ruleClass(ruleClass: String, action: Action<RuleConfig>) {
-        val config = RuleConfig()
-        action.execute(config)
-
-        config.priority?.let { priority ->
-            priorityOverridesByRuleClass.put(ruleClass, priority)
-        }
+        ruleClassOverrides.put(ruleClass, RuleConfig().apply { action.execute(this) })
     }
 }

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
@@ -10,7 +10,12 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.internal.extensions.stdlib.capitalized
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.add
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
 
 class ArchrulesRunnerPlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -87,11 +92,34 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
                 attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
             }
         }
+
         tasks.register<CheckRulesTask>("checkArchRules" + sourceSet.name.capitalized()) {
             description = "Checks ArchRules on ${sourceSet.name}"
             rulesClasspath.setFrom(sourceSetArchRulesRuntime)
-            priorityOverridesByName.set(ext.priorityOverridesByRuleName)
-            priorityOverridesByClass.set(ext.priorityOverridesByRuleClass)
+            priorityOverridesByName.set(
+                ext.ruleOverrides.map {
+                    it.mapValues { it.value.priority }
+                        .filterValues { it != null }
+                        .mapValues { it.value!! } // could be improved by https://youtrack.jetbrains.com/issue/KT-4734
+                }
+            )
+            priorityOverridesByClass.set(
+                ext.ruleClassOverrides.map {
+                    it.mapValues { it.value.priority }
+                        .filterValues { it != null }
+                        .mapValues { it.value!! } // could be improved by https://youtrack.jetbrains.com/issue/KT-4734
+                }
+            )
+            excludedRules.set(
+                ext.ruleOverrides.map {
+                    it.filter { it.value.sourceSetsToSkip.contains(sourceSet.name) }.map { it.key }
+                }
+            )
+            excludedRuleClasses.set(
+                ext.ruleClassOverrides.map {
+                    it.filter { it.value.sourceSetsToSkip.contains(sourceSet.name) }.map { it.key }
+                }
+            )
             dataFile.set(archRulesReportDir.map {
                 it.file(sourceSet.name + ".data").asFile
             })

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/CheckRulesTask.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/CheckRulesTask.kt
@@ -3,6 +3,7 @@ package com.netflix.nebula.archrules.gradle;
 import com.tngtech.archunit.lang.Priority
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
@@ -32,6 +33,12 @@ abstract class CheckRulesTask @Inject constructor(private val workerExecutor: Wo
     @get:Input
     abstract val priorityOverridesByClass: MapProperty<String, Priority>
 
+    @get:Input
+    abstract val excludedRules: ListProperty<String>
+
+    @get:Input
+    abstract val excludedRuleClasses: ListProperty<String>
+
     @TaskAction
     fun checkRules() {
         val workQueue: WorkQueue = workerExecutor.classLoaderIsolation {
@@ -42,6 +49,8 @@ abstract class CheckRulesTask @Inject constructor(private val workerExecutor: Wo
             getDataOutputFile().set(dataFile)
             getPriorityOverridesByName().set(this@CheckRulesTask.priorityOverridesByName)
             getPriorityOverridesByClass().set(this@CheckRulesTask.priorityOverridesByClass)
+            getExcludedRules().set(this@CheckRulesTask.excludedRules)
+            getExcludedRuleClasses().set(this@CheckRulesTask.excludedRuleClasses)
         }
     }
 }

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/RuleConfig.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/RuleConfig.kt
@@ -12,6 +12,7 @@ class RuleConfig {
     }
 
     var priority: Priority? = null
+    val sourceSetsToSkip: MutableList<String> = mutableListOf()
 
     fun priority(priority: String) {
         val validStrings = EnumSet.allOf(Priority::class.java).map { it.asString() }.toSet()
@@ -20,12 +21,16 @@ class RuleConfig {
         } else {
             LOGGER.warn(
                 "Invalid ArchRule priority '$priority'. " +
-                        "Must be one of the following (case-sensitive): ${validStrings.joinToString(", ")}"
+                    "Must be one of the following (case-sensitive): ${validStrings.joinToString(", ")}"
             )
         }
     }
 
     fun priority(priority: Priority) {
         this.priority = priority
+    }
+
+    fun skipSourceSet(name: String) {
+        sourceSetsToSkip.add(name)
     }
 }

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
@@ -484,7 +484,7 @@ archRules {
             }
         }
 
-        val result = runner.run("checkArchRulesMain", "--stacktrace", "-x", "test")
+        val result = runner.run("checkArchRulesMain", "--stacktrace")
 
         assertThat(result.task(":checkArchRulesMain"))
             .`as`("archRules run for main source set")
@@ -507,6 +507,66 @@ archRules {
     }
 
     @Test
+    fun `rule level source set excludes`() {
+        val runner = testProject(projectDir) {
+            setupConsumerProject {
+                rawBuildScript(
+                    """
+archRules {
+    ruleName("deprecated") {
+        skipSourceSet("main")
+    }
+}
+"""
+                )
+            }
+        }
+
+        val result = runner.run("checkArchRulesMain", "--stacktrace", "--info")
+
+        assertThat(result.task(":checkArchRulesMain"))
+            .`as`("archRules run for main source set")
+            .hasOutcome(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE)
+
+        val mainReport = projectDir.resolve("build/reports/archrules/main.data")
+        val results = readDetails(mainReport)
+
+        val deprecatedForRemovalResults = results.filter { it.rule.ruleName.equals("deprecatedForRemoval") }
+        assertThat(deprecatedForRemovalResults).hasSize(1)
+
+        val deprecatedResults = results.filter { it.rule.ruleName.equals("deprecated") }
+        assertThat(deprecatedResults).isEmpty()
+    }
+
+    @Test
+    fun `ruleClass level source set excludes`() {
+        val runner = testProject(projectDir) {
+            setupConsumerProject {
+                rawBuildScript(
+                    """
+archRules {
+    ruleClass("com.netflix.nebula.archrules.deprecation") {
+        skipSourceSet("main")
+    }
+}
+"""
+                )
+            }
+        }
+
+        val result = runner.run("checkArchRulesMain", "--stacktrace")
+
+        assertThat(result.task(":checkArchRulesMain"))
+            .`as`("archRules run for main source set")
+            .hasOutcome(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE)
+
+        val mainReport = projectDir.resolve("build/reports/archrules/main.data")
+        val results = readDetails(mainReport)
+
+        assertThat(results).isEmpty()
+    }
+
+    @Test
     fun `invalid priority string logs warning and does not override`() {
         val runner = testProject(projectDir) {
             setupConsumerProject {
@@ -522,7 +582,7 @@ archRules {
             }
         }
 
-        val result = runner.run("checkArchRulesMain", "--stacktrace", "-x", "test")
+        val result = runner.run("checkArchRulesMain", "--stacktrace")
 
         assertThat(result.output)
             .contains("Invalid ArchRule priority 'NONE'")

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/RunRulesWorkActionTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/RunRulesWorkActionTest.kt
@@ -1,0 +1,49 @@
+package com.netflix.nebula.archrules.gradle
+
+import com.tngtech.archunit.lang.Priority
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+internal class RunRulesWorkActionTest {
+    private fun params(config: RunRulesParams.() -> Unit): RunRulesParams {
+        return ProjectBuilder.builder().build().objects.newInstance(RunRulesParams::class.java).apply(config)
+    }
+
+    private fun instance(params: RunRulesParams): RunRulesWorkAction {
+        return object : RunRulesWorkAction() {
+            override fun getParameters(): RunRulesParams {
+                return params
+            }
+        }
+    }
+
+    @Test
+    fun `test excluded rule class exact match`() {
+        val params = params {
+            excludedRuleClasses.add("test")
+        }
+        val instance = instance(params)
+        assertThat(instance.isRuleClassExcluded("test")).isTrue()
+    }
+
+    @Test
+    fun `test excluded rule class fuzzy match`() {
+        val params = params {
+            excludedRuleClasses.add("com.netflix")
+        }
+        val instance = instance(params)
+        assertThat(instance.isRuleClassExcluded("com.netflix.myrules.MyRuleClass")).isTrue()
+    }
+
+    @Test
+    fun `test multiple class matches`() {
+        val params = params {
+            priorityOverridesByClass.put("com.netflix", Priority.LOW)
+            priorityOverridesByClass.put("com.netflix.important", Priority.HIGH)
+        }
+        val instance = instance(params)
+        assertThat(instance.getPriorityOverride("com.netflix.important.ImportantClass", "whatever id"))
+            .hasValue(Priority.HIGH)
+    }
+}


### PR DESCRIPTION
You can skip evaluating certain rules on specific source sets:
```kotlin
archRules {
    ruleClass("com.netflix.nebula.archrules.deprecation") {
        skipSourceSet("test")
    }
    ruleName("deprecated") {
        skipSourceSet("test")
    }
}
```