### PR TITLE
Don't set the deprecated archrules attribute in the runner plugin

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
@@ -33,7 +33,6 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
             isCanBeConsumed = false
             isCanBeResolved = true
             attributes {
-                attribute(ArchRuleAttribute.ARCH_RULES_ATTRIBUTE, project.objects.named(ARCH_RULES))
                 attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
                 attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named<Category>(Category.LIBRARY))
                 attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.EXTERNAL))


### PR DESCRIPTION
this is part of a phased approach to fully remove the deprecated attribute