### PR TITLE
use old DependencyHandler.project API for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Rules can be sourced from OSS libraries or private internal libraries. You can f
 ### Aggregate Console Report Plugin
 [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/com.netflix.nebula.archrules.aggregate?style=for-the-badge&color=01AF01)](https://plugins.gradle.org/plugin/com.netflix.nebula.archrules.aggregate)
 
+### Gradle Compatibility
+Look at the [SupportedGradleVersions](https://github.com/nebula-plugins/nebula-archrules-plugin/blob/main/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/SupportedGradleVersions.kt) to see what the currently supported range of Gradle versions is.
 
 ## Authoring Rules
 
@@ -237,6 +239,8 @@ archRulesAggregate {
     consoleDetailsThreshold("HIGH")
 }
 ```
+
+To run the aggregate reports, use the `archRulesAggregateMarkdownReport` and `archRulesAggregateConsoleReport` tasks.
 
 #### Filtering specific rules
 If you would like to only display certain rules or rule classes on the CLI, you can use the following flags.

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesAggregateReportPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesAggregateReportPlugin.kt
@@ -22,7 +22,10 @@ class ArchrulesAggregateReportPlugin @Inject constructor(val objects: ObjectFact
         ext.consoleDetailsThreshold(Priority.MEDIUM)
 
         val archRulesDataFiles = project.configurations.detachedConfiguration(
-            *project.subprojects.map { project.dependencies.project(it.path) }.toTypedArray()
+            *project.subprojects.map {
+                // use old API for pre-gradle 9.5 compatibility
+                project.dependencies.project(mapOf("path" to it.path))
+            }.toTypedArray()
         ).apply { description = "projects to collect archrules data from" }
 
         project.tasks.register<PrintConsoleReportTask>("archRulesAggregateConsoleReport") {

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesAggregateReportPluginTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesAggregateReportPluginTest.kt
@@ -12,11 +12,14 @@ import nebula.test.dsl.run
 import nebula.test.dsl.src
 import nebula.test.dsl.subProject
 import nebula.test.dsl.testProject
+import nebula.test.dsl.withGradle
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.io.File
 
 class ArchrulesAggregateReportPluginTest {
@@ -96,13 +99,15 @@ class ArchrulesAggregateReportPluginTest {
         assertThat(extension.consoleDetailsThreshold.get()).isEqualTo(Priority.MEDIUM)
     }
 
-    @Test
-    fun test() {
+    @ParameterizedTest
+    @EnumSource(SupportedGradleVersion::class)
+    fun `test console`(gradle: SupportedGradleVersion) {
         val runner = testProject(projectDir) {
             setup()
         }
         val result = runner.run("archRulesAggregateConsoleReport") {
             forwardOutput()
+            withGradle(gradle.version)
         }
         assertThat(result)
             .hasNoDeprecationWarnings()
@@ -114,13 +119,15 @@ class ArchrulesAggregateReportPluginTest {
             .contains("deprecated            LOW        (4 failures)")
     }
 
-    @Test
-    fun `test markdown`() {
+    @ParameterizedTest
+    @EnumSource(SupportedGradleVersion::class)
+    fun `test markdown`(gradle: SupportedGradleVersion) {
         val runner = testProject(projectDir) {
             setup()
         }
         val result = runner.run("archRulesAggregateMarkdownReport") {
             forwardOutput()
+            withGradle(gradle.version)
         }
         assertThat(result)
             .hasNoDeprecationWarnings()


### PR DESCRIPTION
use old DependencyHandler.project API to be compatible with versions of gradle before 9.5