### PR TITLE
Improve output of `EnforceArchRulesTask`

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/EnforceArchRulesTask.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/EnforceArchRulesTask.kt
@@ -33,10 +33,10 @@ abstract class EnforceArchRulesTask : DefaultTask() {
             .filter { it.status == RuleResultStatus.FAIL }
             .filter { shouldFail(it.rule.priority) }
         if (criticalFailures.isNotEmpty()) {
-            throw RuntimeException(
+            throw VerificationException(
                 "ArchRules failed: ${
                     criticalFailures.joinToString("\n") {
-                        "${it.rule.ruleName} (${it.rule.priority})"
+                        "${it.rule.ruleName} (${it.rule.priority}) ${it.message}"
                     }
                 }"
             )


### PR DESCRIPTION
The `VerificationException` is more appropriate here as this is an intentional failure. Also, the failed rules' messages are now also printed.

Closes #88