### PR TITLE
React to the checkstyle plugin

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPlugin.kt
@@ -120,6 +120,7 @@ class ArchrulesLibraryPlugin : Plugin<Project> {
                         }
                     }
                 }
+                project.tasks.findByName("checkstyleArchRules")?.dependsOn(generateServicesTask)
                 project.tasks.named("check") {
                     dependsOn(ext.suites.named("archRulesTest"))
                 }

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPluginTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPluginTest.kt
@@ -403,4 +403,16 @@ class ArchrulesLibraryPluginTest {
             .contains("## kotlinDeprecated")
             .doesNotContain("## public classes should be @NullMarked")
     }
+
+    @Test
+    fun `react to checkstyle plugin`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("java")
+        project.plugins.apply("checkstyle")
+        project.plugins.apply("com.netflix.nebula.archrules.library")
+        val generateServicesRegistry = project.tasks.getByName("generateServicesRegistry")
+        val checkstyleArchRules = project.tasks.getByName("checkstyleArchRules")
+        val dependencies = checkstyleArchRules.taskDependencies.getDependencies(checkstyleArchRules)
+        assertThat(dependencies).contains(generateServicesRegistry)
+    }
 }


### PR DESCRIPTION
Fix:
```
* What went wrong:
A problem was found with the configuration of task ':xxx-archrules:checkstyleArchRules' (type 'Checkstyle').
  - Gradle detected a problem with the following location: '/xxx/xxx-archrules/build/resources/archRules'.

    Reason: Task ':xxx-archrules:checkstyleArchRules' uses this output of task ':xxx-archrules:generateServicesRegistry' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':xxx-archrules:generateServicesRegistry' as an input of ':xxx-archrules:checkstyleArchRules'.
      2. Declare an explicit dependency on ':xxx-archrules:generateServicesRegistry' from ':xxx-archrules:checkstyleArchRules' using Task#dependsOn.
      3. Declare an explicit dependency on ':xxx-archrules:generateServicesRegistry' from ':xxx-archrules:checkstyleArchRules' using Task#mustRunAfter.

```