### PR TITLE
Fix task ordering

### DIFF
--- a/.github/workflows/archrules.yml
+++ b/.github/workflows/archrules.yml
@@ -1,0 +1,43 @@
+# action for evaluating archrules on a multi project repo
+name: Nebula ArchRules
+on:
+    push:
+        branches:
+            - 'main'
+    pull_request:
+
+jobs:
+    buildmultijdk:
+        runs-on: ubuntu-latest
+        name: ArchRules
+        steps:
+            - uses: actions/checkout@v6
+            - name: Setup git user
+              run: |
+                  git config --global user.name "Nebula Plugin Maintainers"
+                  git config --global user.email "nebula-plugins-oss@netflix.com"
+            - name: Set up JDKs
+              uses: actions/setup-java@v5
+              with:
+                  distribution: 'zulu'
+                  java-version: |
+                    8
+                    17
+                    21
+                  java-package: jdk
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v5
+              with:
+                  cache-overwrite-existing: true
+                  build-scan-publish: true
+                  build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+                  build-scan-terms-of-use-agree: 'yes'
+            - name: Gradle run archrules
+              run: ./gradlew --stacktrace archRulesAggregateConsoleReport archRulesAggregateMarkdownReport
+            - name: Arch Rule Reports step summary
+              run: cat build/reports/archrules/report.md > $GITHUB_STEP_SUMMARY
+            - name: PR Comment
+              if: github.event_name == 'pull_request'
+              run: gh pr comment ${{ github.event.number }} --edit-last --create-if-none -b "[ArchRules report](${{ github.server.url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+              env:
+                  GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: |
-            11
+            8
+            17
             21
             ${{ matrix.java }}
           java-package: jdk

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: |
-            11
+            8
+            17
             21
           java-package: jdk
       - name: Setup Gradle

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPlugin.kt
@@ -58,14 +58,14 @@ class ArchrulesLibraryPlugin : Plugin<Project> {
                             "resources/archRules/META-INF/services/com.netflix.nebula.archrules.core.ArchRulesService"
                         )
                     )
-                    ruleSourceClasses.setFrom(archRulesSourceSet.output)
-                    dependsOn(archRulesSourceSet.classesTaskName)
+                    ruleSourceClasses.from(project.tasks.named<JavaCompile>(archRulesSourceSet.compileJavaTaskName))
+                    project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+                        ruleSourceClasses.from(project.tasks.named(archRulesSourceSet.getCompileTaskName("kotlin")))
+                    }
+                    dependsOn(project.tasks.named(archRulesSourceSet.processResourcesTaskName))
                 }
             project.tasks.named(archRulesSourceSet.classesTaskName) {
-                finalizedBy(generateServicesTask)
-            }
-            project.tasks.named("processArchRulesResources") {
-                finalizedBy(generateServicesTask)
+                dependsOn(generateServicesTask)
             }
             val jarTask = project.tasks.register<Jar>("archRulesJar") {
                 description = "Assembles a jar archive containing the classes of the arch rules."

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/IntegrationTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/IntegrationTest.kt
@@ -249,4 +249,40 @@ internal class IntegrationTest {
             additionalConfig.invoke(this)
         }
     }
+
+    /**
+     * checkstyle is an example of a task that depends on the classes task output of the archRules source set
+     */
+    @Test
+    fun `test checkstyle integration`() {
+        val runner = testProject(projectDir) {
+            properties {
+                buildCache(true)
+                configurationCache(true)
+            }
+            projectWithRules{
+                plugins {
+                    id("checkstyle")
+                }
+            }
+        }
+        projectDir.resolve("config/checkstyle/checkstyle.xml").apply {
+            parentFile.mkdirs()
+            createNewFile()
+            writeText(
+                //language=xml
+                """<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
+  <module name="Checker">
+  </module>
+  """)
+        }
+
+        val result = runner.run("check", "--stacktrace")
+        assertThat(result)
+            .hasNoMutableStateWarnings()
+            .hasNoDeprecationWarnings()
+    }
 }


### PR DESCRIPTION
tasks that depend on the classes task output of the archRules source set were causing gradle to throw an error about missing task dependencies
this PR changes the task wiring to make the service class generation depend directly on each language's compile task, rather than the source set output so that the classes  task can depend on the generate services task