### PR TITLE
Spike fine-grained filters

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/RunRulesParams.java
+++ b/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/RunRulesParams.java
@@ -9,12 +9,15 @@ import org.gradle.workers.WorkParameters;
 import org.jspecify.annotations.NullMarked;
 
 import java.io.File;
+import java.util.List;
 
 @NullMarked
 public interface RunRulesParams extends WorkParameters {
     ConfigurableFileCollection getClassesToCheck();
 
     Property<File> getDataOutputFile();
+
+    MapProperty<String, List<ArchrulesPredicate>> getPredicatesByName();
 
     MapProperty<String, Priority> getPriorityOverridesByName();
 

--- a/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/RunRulesWorkAction.java
+++ b/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/RunRulesWorkAction.java
@@ -2,6 +2,8 @@ package com.netflix.nebula.archrules.gradle;
 
 import com.netflix.nebula.archrules.core.ArchRulesService;
 import com.netflix.nebula.archrules.core.Runner;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.importer.ClassFileImporterWithPackage;
 import com.tngtech.archunit.lang.Priority;
 import org.gradle.workers.WorkAction;
@@ -10,14 +12,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.ServiceLoader;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.netflix.nebula.archrules.core.NoClassesMatchedEvent.NO_MATCH_MESSAGE;
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
 
 @NullMarked
 public abstract class RunRulesWorkAction implements WorkAction<RunRulesParams> {
@@ -79,7 +79,20 @@ public abstract class RunRulesWorkAction implements WorkAction<RunRulesParams> {
                     if (getParameters().getExcludedRules().get().contains(id)) {
                         LOGGER.info("Rule {} has been excluded for this source set", id);
                     } else {
-                        final var result = Runner.check(archRule, classesToCheck);
+                        final var predicates = getParameters().getPredicatesByName().orElse(Map.of()).get().getOrDefault(id, List.of());
+
+                        var classesToCheckForRule = classesToCheck;
+                        for (var predicate : predicates) {
+                            classesToCheckForRule = classesToCheckForRule
+                                .that(convertPredicate(predicate));
+                        }
+
+                        // TODO Remove debug prints
+                        System.out.println("RULE: " + id);
+                        System.out.println("PREDICATES: " + predicates);
+                        System.out.println("CLASSES: " + classesToCheckForRule);
+
+                        final var result = Runner.check(archRule, classesToCheckForRule);
 
                         // check if there is priority override by class first
                         var priority = getPriorityOverride(ruleClassName, id).orElse(result.getPriority());
@@ -103,4 +116,23 @@ public abstract class RunRulesWorkAction implements WorkAction<RunRulesParams> {
 
         ViolationsUtil.writeDetails(getParameters().getDataOutputFile().get(), violationList);
     }
+
+    private DescribedPredicate<JavaClass> convertPredicate(ArchrulesPredicate predicate) {
+        class ConvertingVisitor implements ArchrulesPredicateVisitor<DescribedPredicate<JavaClass>> {
+
+            @Override
+            public DescribedPredicate<JavaClass> visitNot(ArchrulesPredicate.NotPredicate predicate) {
+                return not(predicate.getPredicate().accept(this));
+            }
+
+            @Override
+            public DescribedPredicate<JavaClass> visitSimpleName(ArchrulesPredicate.SimpleNamePredicate predicate) {
+                return simpleName(predicate.getName());
+            }
+
+        }
+
+        return predicate.accept( new ConvertingVisitor());
+    }
+
 }

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesPredicate.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesPredicate.kt
@@ -1,0 +1,31 @@
+package com.netflix.nebula.archrules.gradle
+
+import java.io.Serializable
+
+fun not(predicate: ArchrulesPredicate): ArchrulesPredicate =
+    ArchrulesPredicate.NotPredicate(predicate)
+
+fun simpleName(name: String): ArchrulesPredicate =
+    ArchrulesPredicate.SimpleNamePredicate(name)
+
+sealed class ArchrulesPredicate : Serializable {
+
+    abstract fun <R> accept(visitor: ArchrulesPredicateVisitor<R>): R
+
+    class NotPredicate(val predicate: ArchrulesPredicate) : ArchrulesPredicate() {
+        override fun <R> accept(visitor: ArchrulesPredicateVisitor<R>): R = visitor.visitNot(this)
+    }
+
+    class SimpleNamePredicate(val name: String) : ArchrulesPredicate() {
+        override fun <R> accept(visitor: ArchrulesPredicateVisitor<R>): R = visitor.visitSimpleName(this)
+    }
+
+}
+
+interface ArchrulesPredicateVisitor<R> {
+
+    fun visitNot(predicate: ArchrulesPredicate.NotPredicate): R
+
+    fun visitSimpleName(predicate: ArchrulesPredicate.SimpleNamePredicate): R
+
+}

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
@@ -124,6 +124,11 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
         tasks.register<CheckRulesTask>("checkArchRules" + sourceSet.name.capitalized()) {
             description = "Checks ArchRules on ${sourceSet.name}"
             rulesClasspath.setFrom(sourceSetArchRulesRuntime)
+            predicatesByName.set(
+                ext.ruleOverrides.map {
+                    it.mapValues { it.value.predicates }
+                }
+            )
             priorityOverridesByName.set(
                 ext.ruleOverrides.map {
                     it.mapValues { it.value.priority }

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/CheckRulesTask.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/CheckRulesTask.kt
@@ -28,6 +28,9 @@ abstract class CheckRulesTask @Inject constructor(private val workerExecutor: Wo
     abstract val dataFile: Property<File>
 
     @get:Input
+    abstract val predicatesByName: MapProperty<String, List<ArchrulesPredicate>>
+
+    @get:Input
     abstract val priorityOverridesByName: MapProperty<String, Priority>
 
     @get:Input
@@ -47,6 +50,7 @@ abstract class CheckRulesTask @Inject constructor(private val workerExecutor: Wo
         workQueue.submit(RunRulesWorkAction::class) {
             getClassesToCheck().from(sourcesToCheck)
             getDataOutputFile().set(dataFile)
+            getPredicatesByName().set(this@CheckRulesTask.predicatesByName)
             getPriorityOverridesByName().set(this@CheckRulesTask.priorityOverridesByName)
             getPriorityOverridesByClass().set(this@CheckRulesTask.priorityOverridesByClass)
             getExcludedRules().set(this@CheckRulesTask.excludedRules)

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/RuleConfig.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/RuleConfig.kt
@@ -14,6 +14,12 @@ class RuleConfig {
     var priority: Priority? = null
     val sourceSetsToSkip: MutableList<String> = mutableListOf()
 
+    val predicates: MutableList<ArchrulesPredicate> = mutableListOf()
+
+    fun classesThat(predicate: ArchrulesPredicate) {
+        predicates += predicate
+    }
+
     fun priority(priority: String) {
         val validStrings = EnumSet.allOf(Priority::class.java).map { it.asString() }.toSet()
         if (validStrings.contains(priority)) {

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
@@ -17,6 +17,7 @@ import nebula.test.dsl.subProject
 import nebula.test.dsl.test
 import nebula.test.dsl.testProject
 import nebula.test.dsl.withGradle
+import org.assertj.core.api.Assertions.from
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.named
 import org.gradle.testfixtures.ProjectBuilder
@@ -641,6 +642,40 @@ archRules {
 
         val deprecatedResults = results.filter { it.rule.ruleName == "deprecated" }
         assertThat(deprecatedResults).isEmpty()
+    }
+
+    @Test
+    fun `rule level fine-grained filtering`() {
+        val runner = testProject(projectDir) {
+            setupConsumerProject {
+                rawBuildScript(
+                    """
+archRules {
+    ruleName("deprecated") {
+        classesThat(com.netflix.nebula.archrules.gradle.not(com.netflix.nebula.archrules.gradle.simpleName("FailingCode")))
+    }
+}
+"""
+                )
+            }
+        }
+
+        val result = runner.run("checkArchRulesMain", "--stacktrace", "--info")
+
+        assertThat(result.task(":checkArchRulesMain"))
+            .`as`("archRules run for main source set")
+            .hasOutcome(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE)
+
+        val mainReport = projectDir.resolve("build/reports/archrules/main.data")
+        val results = readDetails(mainReport)
+
+        val deprecatedForRemovalResults = results.filter { it.rule.ruleName == "deprecatedForRemoval" }
+        assertThat(deprecatedForRemovalResults).hasSize(1)
+
+        val deprecatedResults = results.filter { it.rule.ruleName == "deprecated" }
+        assertThat(deprecatedResults)
+            .singleElement()
+            .returns(RuleResultStatus.PASS, from(RuleResult::status))
     }
 
     @Test


### PR DESCRIPTION
This is a rough sketch of what I had in mind as a potential solution to #91. The core idea is that we define an extensible, serializable predicate data structure that loosely corresponds to ArchUnit's own predicate DSL.

This could then be used globally or per-rule (and hopefully eventually per sourceset) as follows:

```kotlin
archRules {
    ruleName("deprecated") {
        classesThat(not(simpleName("FailingCode")))
    }
}
```

Behind the scenes, this is trivially mapped to ArchUnit `DescribedPredicate<JavaClass>` instances using the visitor pattern and applied to each `JavaClasses` instance before checking the rule against it.

Let me know what you think of this approach, and if you like it, I'll flesh this out into a proper PR.

See #91