### PR TITLE
archRulesRuntime configurations should resolve consistently with the configuration they are extending

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
@@ -119,6 +119,7 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
                 attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
                 attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.CLASSES))
             }
+            shouldResolveConsistentlyWith(configurations.getByName(sourceSet.runtimeClasspathConfigurationName))
         }
 
         tasks.register<CheckRulesTask>("checkArchRules" + sourceSet.name.capitalized()) {

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
@@ -884,4 +884,31 @@ archRules {
                 .contains("Solution: Fix critical errors reported in Problems Report")
         }
     }
+
+    @Test
+    fun `archRulesRuntime configuration respects resolution rules`() {
+        val runner = testProject(projectDir) {
+            setupConsumerProject(ruleDependency = true) {
+                dependencies(
+                    """implementation("com.google.guava:guava")"""
+                )
+                rawBuildScript("""
+configurations.named("runtimeClasspath") {
+    resolutionStrategy.dependencySubstitution {
+        substitute(module("com.google.guava:guava")).using(module("com.google.guava:guava:21.0"))
+    }
+}
+""")
+            }
+        }
+        val resultRuntime = runner.run("dependencyInsight", "--stacktrace",
+            "--configuration", "runtimeClasspath",
+            "--dependency","guava")
+        val result = runner.run("dependencyInsight", "--stacktrace",
+            "--configuration", "mainArchRulesRuntime",
+            "--dependency","guava")
+        assertThat(result.output)
+            .doesNotContain("FAILED")
+            .contains("com.google.guava:guava:21.0")
+    }
 }


### PR DESCRIPTION
archRulesRuntime configurations should resolve consistently with the configuration they are extending in order to respect resolution rules