### PR TITLE
stale archrules outputs for skipped source sets should not be used by enforceArchRules task

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
@@ -155,7 +155,7 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
             sourcesToCheck.from(sourceSet.output.classesDirs)
             dependsOn(project.tasks.named(sourceSet.classesTaskName))
             val sourceSetName = sourceSet.name
-            onlyIf { !ext.sourceSetsToSkip.get().contains(sourceSetName) }
+            skip.set(ext.sourceSetsToSkip.map { it.contains(sourceSetName) })
         }
     }
 }

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/CheckRulesTask.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/CheckRulesTask.kt
@@ -1,4 +1,4 @@
-package com.netflix.nebula.archrules.gradle;
+package com.netflix.nebula.archrules.gradle
 
 import com.tngtech.archunit.lang.Priority
 import org.gradle.api.DefaultTask
@@ -6,7 +6,13 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.submit
 import org.gradle.workers.WorkQueue
 import org.gradle.workers.WorkerExecutor
@@ -39,18 +45,27 @@ abstract class CheckRulesTask @Inject constructor(private val workerExecutor: Wo
     @get:Input
     abstract val excludedRuleClasses: ListProperty<String>
 
+    @get:Input
+    abstract val skip: Property<Boolean>
+
     @TaskAction
     fun checkRules() {
-        val workQueue: WorkQueue = workerExecutor.classLoaderIsolation {
-            classpath.from(rulesClasspath)
-        }
-        workQueue.submit(RunRulesWorkAction::class) {
-            getClassesToCheck().from(sourcesToCheck)
-            getDataOutputFile().set(dataFile)
-            getPriorityOverridesByName().set(this@CheckRulesTask.priorityOverridesByName)
-            getPriorityOverridesByClass().set(this@CheckRulesTask.priorityOverridesByClass)
-            getExcludedRules().set(this@CheckRulesTask.excludedRules)
-            getExcludedRuleClasses().set(this@CheckRulesTask.excludedRuleClasses)
+        if (skip.getOrElse(false)) {
+            if (dataFile.get().exists()) {
+                dataFile.get().delete()
+            }
+        } else {
+            val workQueue: WorkQueue = workerExecutor.classLoaderIsolation {
+                classpath.from(rulesClasspath)
+            }
+            workQueue.submit(RunRulesWorkAction::class) {
+                getClassesToCheck().from(sourcesToCheck)
+                getDataOutputFile().set(dataFile)
+                getPriorityOverridesByName().set(this@CheckRulesTask.priorityOverridesByName)
+                getPriorityOverridesByClass().set(this@CheckRulesTask.priorityOverridesByClass)
+                getExcludedRules().set(this@CheckRulesTask.excludedRules)
+                getExcludedRuleClasses().set(this@CheckRulesTask.excludedRuleClasses)
+            }
         }
     }
 }

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPluginTest.kt
@@ -556,7 +556,12 @@ archRules {
 
         assertThat(result.task(":checkArchRulesArchRulesTest"))
             .`as`("archRules run for test source set")
-            .hasOutcome(TaskOutcome.SKIPPED)
+            .hasOutcome(TaskOutcome.SUCCESS)
+
+        val archRulesTestReport = projectDir.resolve("build/reports/archrules/archRulesTest.data")
+        assertThat(archRulesTestReport)
+            .`as`("archRulesTestReport data not created")
+            .doesNotExist()
 
         assertThat(result)
             .hasNoMutableStateWarnings()
@@ -584,8 +589,13 @@ archRules {
             .hasOutcome(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE)
 
         assertThat(result.task(":checkArchRulesTest"))
-            .`as`("archRules run for test source set")
-            .hasOutcome(TaskOutcome.SKIPPED)
+            .`as`("tasks for skipped sources set still runs")
+            .hasOutcome(TaskOutcome.SUCCESS)
+
+        val archRulesTestReport = projectDir.resolve("build/reports/archrules/test.data")
+        assertThat(archRulesTestReport)
+            .`as`("skipped sources set data not created")
+            .doesNotExist()
 
         assertThat(result)
             .hasNoMutableStateWarnings()
@@ -922,6 +932,36 @@ archRules {
                 .`as`("enhanced problems output in newer gradle versions")
                 .contains("Solution: Fix critical errors reported in Problems Report")
         }
+    }
+
+    @Test
+    fun `plugin verification with stale skipped reports`() {
+        val runner = testProject(projectDir) {
+            setupConsumerProject {
+                rawBuildScript(
+                    """
+archRules {
+    failureThreshold("MEDIUM")
+}
+"""
+                )
+            }
+        }
+
+        val result = runner.runAndFail("check", "--stacktrace", "-x", "test")
+
+        assertThat(result.task(":enforceArchRules"))
+            .`as`("verification task fails")
+            .hasOutcome(TaskOutcome.FAILED)
+        projectDir.resolve("build.gradle.kts").appendText("""
+archRules {
+    skipSourceSet("main")
+}
+""")
+        val result2 = runner.run("check", "--stacktrace", "-x", "test")
+        assertThat(result2.task(":enforceArchRules"))
+            .`as`("verification task passes")
+            .hasOutcome(TaskOutcome.SUCCESS)
     }
 
     @Test


### PR DESCRIPTION
stale archrules outputs for skipped source sets should not be used by enforceArchRules task

fixes #98