### PR TITLE
fix stackoverflow in aggregate report configuration

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesAggregateReportPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesAggregateReportPlugin.kt
@@ -8,7 +8,6 @@ import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.VerificationType
 import org.gradle.api.model.ObjectFactory
 import org.gradle.kotlin.dsl.named
-import org.gradle.kotlin.dsl.project
 import org.gradle.kotlin.dsl.register
 import javax.inject.Inject
 
@@ -27,16 +26,15 @@ class ArchrulesAggregateReportPlugin @Inject constructor(val objects: ObjectFact
                 project.dependencies.project(mapOf("path" to it.path))
             }.toTypedArray()
         ).apply { description = "projects to collect archrules data from" }
+        archRulesDataFiles.attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, verification)
+            attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, archRulesVerificationType)
+        }
 
         project.tasks.register<PrintConsoleReportTask>("archRulesAggregateConsoleReport") {
             dataFiles.from(
                 archRulesDataFiles.incoming.artifactView {
-                    withVariantReselection()
                     lenient(true) // to handle the case where a subproject doesn't have archrules runner
-                    attributes {
-                        attribute(Category.CATEGORY_ATTRIBUTE, verification)
-                        attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, archRulesVerificationType)
-                    }
                 }.artifacts.resolvedArtifacts.map {
                     // filter for only artifacts that match the attributes
                     it.filter {
@@ -53,12 +51,7 @@ class ArchrulesAggregateReportPlugin @Inject constructor(val objects: ObjectFact
         project.tasks.register<PrintMarkdownReportTask>("archRulesAggregateMarkdownReport") {
             dataFiles.from(
                 archRulesDataFiles.incoming.artifactView {
-                    withVariantReselection()
                     lenient(true) // to handle the case where a subproject doesn't have archrules runner
-                    attributes {
-                        attribute(Category.CATEGORY_ATTRIBUTE, verification)
-                        attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, archRulesVerificationType)
-                    }
                 }.artifacts.resolvedArtifacts.map {
                     // filter for only artifacts that match the attributes
                     it.filter {

--- a/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesAggregateReportPluginTest.kt
+++ b/nebula-archrules-gradle-plugin/src/test/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesAggregateReportPluginTest.kt
@@ -1,6 +1,7 @@
 package com.netflix.nebula.archrules.gradle
 
 import com.tngtech.archunit.lang.Priority
+import nebula.test.dsl.ProjectBuilder
 import nebula.test.dsl.TestKitAssertions.assertThat
 import nebula.test.dsl.TestProjectBuilder
 import nebula.test.dsl.main
@@ -14,7 +15,6 @@ import nebula.test.dsl.subProject
 import nebula.test.dsl.testProject
 import nebula.test.dsl.withGradle
 import org.gradle.kotlin.dsl.findByType
-import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -26,17 +26,20 @@ class ArchrulesAggregateReportPluginTest {
     @TempDir
     lateinit var projectDir: File
 
-    private fun TestProjectBuilder.setup(withFailures: Boolean = true) {
+    private fun TestProjectBuilder.multiprojectSetup() {
         properties {
             buildCache(true)
             configurationCache(true)
-            property("org.gradle.unsafe.isolated-projects","true")
+            property("org.gradle.unsafe.isolated-projects", "true")
         }
         rootProject {
             plugins {
                 id("com.netflix.nebula.archrules.aggregate")
             }
         }
+    }
+
+    private fun TestProjectBuilder.libraryProject() {
         subProject("library") {
             plugins {
                 id("java")
@@ -47,7 +50,14 @@ class ArchrulesAggregateReportPluginTest {
                 }
             }
         }
-        subProject("sub1") {
+    }
+
+    private fun TestProjectBuilder.consumerProject(
+        name: String,
+        failingClassName: String? = null,
+        dsl: ProjectBuilder.() -> Unit = {}
+    ) {
+        subProject(name) {
             plugins {
                 id("java")
                 id("com.netflix.nebula.archrules.runner")
@@ -61,37 +71,30 @@ class ArchrulesAggregateReportPluginTest {
             )
             src {
                 main {
-                    if (withFailures) {
-                        exampleDeprecatedUsage("FailingCode1")
+                    if (failingClassName != null) {
+                        exampleDeprecatedUsage(failingClassName)
                     }
                 }
             }
+            dsl()
         }
-        subProject("sub2") {
-            plugins {
-                id("java")
-                id("com.netflix.nebula.archrules.runner")
-            }
-            repositories {
-                mavenCentral()
-            }
-            dependencies(
-                """implementation(project(":library"))""",
-                """archRules("com.netflix.nebula:archrules-deprecation:0.+")"""
-            )
-            src {
-                main {
-                    if (withFailures) {
-                        exampleDeprecatedUsage("FailingCode2")
-                    }
-                }
-            }
+    }
+
+    private fun TestProjectBuilder.setup(withFailures: Boolean = true) {
+        multiprojectSetup()
+        libraryProject()
+        if (withFailures) {
+            consumerProject("sub1", "FailingCode1")
+            consumerProject("sub2", "FailingCode2")
+        } else {
+            consumerProject("sub1")
+            consumerProject("sub2")
         }
     }
 
     @Test
     fun `settings defaults`() {
-        val project = ProjectBuilder.builder().build()
+        val project = org.gradle.testfixtures.ProjectBuilder.builder().build()
         project.plugins.apply("java")
         project.plugins.apply("com.netflix.nebula.archrules.aggregate")
         val extension = project.extensions.findByType<ArchrulesAggregateExtension>()!!


### PR DESCRIPTION
reproduction is only possible when the aggregate configuration resolution throws an exception, not a simple FAILED resolution. therefore I was not able to reproduce this in a test