### PR TITLE
restore separate `com.netflix.nebula.archrules` attribute

### DIFF
--- a/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/ArchRuleAttribute.java
+++ b/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/ArchRuleAttribute.java
@@ -9,6 +9,13 @@ import org.jspecify.annotations.NullMarked;
  */
 @NullMarked
 public interface ArchRuleAttribute extends Named {
+
+    /**
+     * Attribute used to denote an archrules library, and to resolve archrules variants
+     */
+    Attribute<ArchRuleAttribute> ARCH_RULES_ATTRIBUTE =
+            Attribute.of("com.netflix.nebula.archrules", ArchRuleAttribute.class);
+
     /**
      * Used in archrules artifacts to allow them to be selected via the variant selection algorithm
      */

--- a/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/PrintJsonReportTask.java
+++ b/nebula-archrules-gradle-plugin/src/main/java/com/netflix/nebula/archrules/gradle/PrintJsonReportTask.java
@@ -2,15 +2,13 @@ package com.netflix.nebula.archrules.gradle;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Property;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.*;
 import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecutor;
 import org.jspecify.annotations.NullMarked;
 
 import javax.inject.Inject;
-import java.io.File;
 
 /**
  * Produces a JSON report of all ArchRules failures
@@ -32,7 +30,7 @@ abstract public class PrintJsonReportTask extends DefaultTask {
      * @return file for output
      */
     @OutputFile
-    abstract public Property<File> getJsonReportFile();
+    abstract public RegularFileProperty getJsonReportFile();
 
     @Classpath
     abstract public ConfigurableFileCollection getReportingClasspath();
@@ -50,7 +48,7 @@ abstract public class PrintJsonReportTask extends DefaultTask {
                         workerSpec.getClasspath().from(getReportingClasspath()));
         workQueue.submit(JsonReportWorkAction.class, parameters -> {
             parameters.getDataFiles().set(getDataFiles());
-            parameters.getJsonReportFile().set(getJsonReportFile());
+            parameters.getJsonReportFile().set(getJsonReportFile().getAsFile());
         });
     }
 }

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesLibraryPlugin.kt
@@ -4,7 +4,6 @@ import com.netflix.nebula.archrules.gradle.ArchRuleAttribute.ARCH_RULES
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.attributes.Usage
-import org.gradle.api.attributes.java.TargetJvmEnvironment
 import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact
 import org.gradle.api.internal.project.ProjectInternal
@@ -18,8 +17,13 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.add
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.kotlin.dsl.withType
 import org.gradle.testing.base.TestingExtension
 
 class ArchrulesLibraryPlugin : Plugin<Project> {
@@ -31,20 +35,27 @@ class ArchrulesLibraryPlugin : Plugin<Project> {
                 compatibilityRules.add(ArchRuleCompatibilityRule::class)
             }
             val javaExt = project.extensions.getByType<JavaPluginExtension>()
+            val mainSourceSet = javaExt.sourceSets.getByName("main")
             val archRulesSourceSet = javaExt.sourceSets.create("archRules")
             project.configurations.named(archRulesSourceSet.implementationConfigurationName).configure {
                 extendsFrom(project.configurations.getByName(javaExt.sourceSets.getByName("main").implementationConfigurationName))
             }
             project.configurations.named(archRulesSourceSet.runtimeClasspathConfigurationName).configure {
                 attributes {
+                    addAllLater(
+                        project.configurations.named(mainSourceSet.runtimeClasspathConfigurationName).get().attributes
+                    )
+                    attribute(ArchRuleAttribute.ARCH_RULES_ATTRIBUTE, project.objects.named(ARCH_RULES))
                     attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
-                    attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, project.objects.named(TargetJvmEnvironment.STANDARD_JVM))
                 }
             }
             project.configurations.named(archRulesSourceSet.compileClasspathConfigurationName).configure {
                 attributes {
+                    addAllLater(
+                        project.configurations.named(mainSourceSet.compileClasspathConfigurationName).get().attributes
+                    )
+                    attribute(ArchRuleAttribute.ARCH_RULES_ATTRIBUTE, project.objects.named(ARCH_RULES))
                     attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
-                    attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, project.objects.named(TargetJvmEnvironment.STANDARD_JVM))
                 }
             }
             project.dependencies.add(
@@ -111,12 +122,14 @@ class ArchrulesLibraryPlugin : Plugin<Project> {
                             project.configurations.named(runtimeClasspathConfigurationName).configure {
                                 extendsFrom(project.configurations.getByName(archRulesSourceSet.runtimeClasspathConfigurationName))
                                 attributes {
+                                    attribute(ArchRuleAttribute.ARCH_RULES_ATTRIBUTE, project.objects.named(ARCH_RULES))
                                     attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
                                 }
                             }
                             project.configurations.named(compileClasspathConfigurationName).configure {
                                 extendsFrom(project.configurations.getByName(archRulesSourceSet.compileClasspathConfigurationName))
                                 attributes {
+                                    attribute(ArchRuleAttribute.ARCH_RULES_ATTRIBUTE, project.objects.named(ARCH_RULES))
                                     attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
                                 }
                             }
@@ -146,7 +159,7 @@ class ArchrulesLibraryPlugin : Plugin<Project> {
                 projectInternal.fileResolver,
                 projectInternal.taskDependencyFactory
             )
-
+            val mainSourceSet = project.extensions.getByType<JavaPluginExtension>().sourceSets.getByName("main")
             project.configurations.consumable("archRulesRuntimeElements") {
                 jvmLanguageUtilities.useDefaultTargetPlatformInference(this, compileJava)
                 jvmPluginServices.configureAsRuntimeElements(this)
@@ -157,8 +170,11 @@ class ArchrulesLibraryPlugin : Plugin<Project> {
                 )
                 outgoing.artifacts.add(jarArtifact)
                 attributes {
+                    addAllLater(
+                        project.configurations.named(mainSourceSet.runtimeElementsConfigurationName).get().attributes
+                    )
+                    attribute(ArchRuleAttribute.ARCH_RULES_ATTRIBUTE, project.objects.named(ARCH_RULES))
                     attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
-                    attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, project.objects.named(TargetJvmEnvironment.STANDARD_JVM))
                 }
             }
             val adhocComponent = component as AdhocComponentWithVariants

--- a/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
+++ b/nebula-archrules-gradle-plugin/src/main/kotlin/com/netflix/nebula/archrules/gradle/ArchrulesRunnerPlugin.kt
@@ -33,6 +33,7 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
             isCanBeConsumed = false
             isCanBeResolved = true
             attributes {
+                attribute(ArchRuleAttribute.ARCH_RULES_ATTRIBUTE, project.objects.named(ARCH_RULES))
                 attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
                 attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named<Category>(Category.LIBRARY))
                 attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.EXTERNAL))
@@ -58,7 +59,7 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
 
             val jsonReportTask = project.tasks.register<PrintJsonReportTask>("archRulesJsonReport") {
                 dataFiles.from(project.tasks.withType<CheckRulesTask>())
-                getJsonReportFile().set(archRulesReportDir.map { it.file("report.json").asFile })
+                getJsonReportFile().set(archRulesReportDir.map { it.file("report.json") })
                 reportingClasspath.setFrom(project.configurations.detachedConfiguration(
                     project.dependencies.create(ARCHRULES_DEPENDENCY),
                     project.dependencies.create(JACKSON_DEPENDENCY)
@@ -116,6 +117,7 @@ class ArchrulesRunnerPlugin : Plugin<Project> {
             )
             attributes.addAllLater(project.configurations.getByName(sourceSet.compileClasspathConfigurationName).attributes)
             attributes {
+                attribute(ArchRuleAttribute.ARCH_RULES_ATTRIBUTE, project.objects.named(ARCH_RULES))
                 attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(ARCH_RULES))
                 attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.CLASSES))
             }


### PR DESCRIPTION
this attribute helps with variant matching when there are some slight other differences between runtimeElements and archRules variants